### PR TITLE
Fix Memcache::set to respect the StorageInterface

### DIFF
--- a/src/Domino/CacheStore/Storage/Memcache.php
+++ b/src/Domino/CacheStore/Storage/Memcache.php
@@ -62,13 +62,12 @@ class Memcache implements StorageInterface
      * @param mixed   $value
      * @param integer $ttl       expiration time (sec)
      */
-    public function set($namespace, $key, $value, $flag = null, $ttl = null)
+    public function set($namespace, $key, $value, $ttl = null)
     {
         $store_key = $this->getStoreKey($namespace, $key);
         $expire    = is_null($ttl) ? $this->default_ttl : $ttl;
-        $flag    = is_null($ttl) ? $this->default_flag : $flag;
 
-        return $this->connect->set($store_key, $value, $flag, $expire);
+        return $this->connect->set($store_key, $value, $this->default_flag , $expire);
     }
 
     /**

--- a/tests/Domino/CacheStore/Tests/Storage/MemcacheTest.php
+++ b/tests/Domino/CacheStore/Tests/Storage/MemcacheTest.php
@@ -40,12 +40,22 @@ class MemcacheTest extends \PHPUnit_Framework_TestCase
         $this->memcache->clearAll();
     }
 
+    public function testObjectIsInstanceOfStorageInterface(){
+        $this->assertInstanceOf('Domino\CacheStore\Storage\StorageInterface', $this->memcache);
+    }
+
+    /**
+     * @depends testObjectIsInstanceOfStorageInterface
+     */
     public function testSetAndGet()
     {
         $this->memcache->set('namespace', 'key', 'value');
         $this->assertEquals('value', $this->memcache->get('namespace', 'key'));
     }
 
+    /**
+     * @depends testObjectIsInstanceOfStorageInterface
+     */
     public function testClear()
     {
         $this->memcache->set('namespace', 'key', 'value');
@@ -53,6 +63,9 @@ class MemcacheTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->memcache->get('namespace', 'key'));
     }
 
+    /**
+     * @depends testObjectIsInstanceOfStorageInterface
+     */
     public function testClearAll()
     {
         $this->memcache->set('namespace1', 'key1', 'value1');
@@ -62,6 +75,9 @@ class MemcacheTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->memcache->get('namespace2', 'key2'));
     }
 
+    /**
+     * @depends testObjectIsInstanceOfStorageInterface
+     */
     public function testClearByNamespace()
     {
         $this->memcache->set('namespace1', 'key1', 'value1');


### PR DESCRIPTION
 (a flag argument is not allowed in set method)

Added check in Memcache class to confirm it is an instance of StorageInterface