### PR TITLE
Reuses existing connections for a given storage type.

### DIFF
--- a/src/Domino/CacheStore/Factory.php
+++ b/src/Domino/CacheStore/Factory.php
@@ -26,6 +26,11 @@ class Factory
     private static $options = array();
 
     /**
+     * @var array Cache of established connections (to eliminate overhead).
+     */
+    private static $connectionMap=array();
+
+    /**
      * Registered storage
      * @var array
      */
@@ -98,7 +103,12 @@ class Factory
         if (!array_key_exists($storage_type, self::$storage)) {
             throw new StorageException(sprintf('Storage class not set for type %s', $storage_type));
         }
-        return new self::$storage[$storage_type](self::getOption($storage_type));
+        if(!isset(self::$connectionMap[$storage_type]))
+        {
+            self::$connectionMap[$storage_type]= new self::$storage[$storage_type](self::getOption($storage_type));
+        }
+
+        return self::$connectionMap[$storage_type];
     }
 
     /**


### PR DESCRIPTION
passed test and should work as long as the same "options" are used for every cache call to a given storage type.
If a cache call is made to an existing storage type, but with different options (host or whatever) it'll be ignored and the same connection will be used.
In most case this should not be a problem, the cache should usually use the same options during a single execution, but I can see this being a possible problem.