### PR TITLE
Added possibility to disable caching at runtime 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 vendor
 composer.lock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-DominoCacheStore
-=================
+# DominoCacheStore
+
 [![Build Status](https://travis-ci.org/SNakano/CacheStore.png)](https://travis-ci.org/SNakano/CacheStore)
 [![Latest Stable Version](https://poser.pugx.org/snakano/cache-store/v/stable.svg)](https://packagist.org/packages/snakano/cache-store)
 [![Total Downloads](https://poser.pugx.org/snakano/cache-store/downloads.svg)](https://packagist.org/packages/snakano/cache-store)
@@ -12,8 +12,7 @@ provides a generic way to cache any data.
 - support namespace. (use namespace delete)
 
 
-Install
--------
+## Install
 
 using Composer(recommended):
 
@@ -27,8 +26,7 @@ using Composer(recommended):
 or cloning this repository.
 
 
-Usage
------
+## Usage
 
 ```php
 // configure cache setting.
@@ -89,9 +87,18 @@ $storage->get('ns2', 'key1');
 $storage->clearAll();
 $storage->get('ns2', 'key1');
 # => null
+
+// disable caching at runtime
+Domino\CacheStore\Factory::disableCaching();
+// since caching is disabled, the factory will return an instance of "NoCache"
+$storage = Domino\CacheStore\Factory::factory('memcached');
+
+// enable caching at runtime
+Domino\CacheStore\Factory::enableCaching();
+// since caching is enabled again, the factory will return an instance of "Memcached"
+$storage = Domino\CacheStore\Factory::factory('memcached');
 ```
 
-License
--------
+## License
 
 MIT license.

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8||~5.1"
+    },
     "suggest": {
         "ext-apc": "APC >= 3.1.6 to use the APC storage adapter",
         "ext-apcu": "APCu >= 4.0.0 to use the APC User Cache",

--- a/src/Domino/CacheStore/Factory.php
+++ b/src/Domino/CacheStore/Factory.php
@@ -10,6 +10,7 @@
 namespace Domino\CacheStore;
 
 use Domino\CacheStore\Exception\StorageException;
+use Domino\CacheStore\Storage\StorageInterface;
 
 /**
  * Domino Cache Store Factory
@@ -30,6 +31,9 @@ class Factory
      */
     private static $connectionMap = array();
 
+    /** @var bool */
+    private static $cachingIsDisabled = false;
+
     /**
      * Registered storage
      * @var array
@@ -38,6 +42,7 @@ class Factory
         'apc'       => 'Domino\CacheStore\Storage\Apc',
         'memcached' => 'Domino\CacheStore\Storage\Memcached',
         'memcache'  => 'Domino\CacheStore\Storage\Memcache',
+        'nocache'   => 'Domino\CacheStore\Storage\NoCache',
         'redis'     => 'Domino\CacheStore\Storage\Redis',
     );
 
@@ -104,15 +109,39 @@ class Factory
     }
 
     /**
+     * Changes the behavior of the method factory
+     * If you trigger this method, you will get back a NoCache storage
+     */
+    public static function disableCaching()
+    {
+        self::$cachingIsDisabled = true;
+    }
+
+    /**
+     * Resets behavior of the method factory
+     * If you trigger this method, you will get back the storage you want to
+     *
+     * HINT:
+     *  If you enable caching, I recommend to clear the cache right afterwards.
+     */
+    public static function enableCaching()
+    {
+        self::$cachingIsDisabled = false;
+    }
+
+    /**
      * Instantiate a cache storage
      * @param  string  $storage_type cache store storage type (eg. 'apc', 'memcached')
-     * @return Storage               cache store storage instance
+     * @return StorageInterface               cache store storage instance
      * @throws StorageException when $storage_type is not registered
      */
     public static function factory($storage_type)
     {
         if (!array_key_exists($storage_type, self::$storage)) {
             throw new StorageException(sprintf('Storage class not set for type %s', $storage_type));
+        }
+        if (self::$cachingIsDisabled) {
+            $storage_type = 'nocache';
         }
         if (!isset(self::$connectionMap[$storage_type])) {
             self::$connectionMap[$storage_type] = new self::$storage[$storage_type](self::getOption($storage_type));
@@ -124,8 +153,8 @@ class Factory
     /**
      * Register a cache storage
      *
-     * @param $storage_type cache store storage type (eg. 'apc', 'memcached', 'my_apc')
-     * @param $storage_class class name which must implement Domino\CacheStore\Storage\StorageInterface
+     * @param string $storage_type cache store storage type (eg. 'apc', 'memcached', 'my_apc')
+     * @param string $storage_class class name which must implement Domino\CacheStore\Storage\StorageInterface
      * @throws StorageException when $storage_class not implements Domino\CacheStore\Storage\StorageInterface
      */
     public static function registerStorage($storage_type, $storage_class)

--- a/src/Domino/CacheStore/Storage/NoCache.php
+++ b/src/Domino/CacheStore/Storage/NoCache.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @author: stev leibelt <artodeto@bazzline.net>
+ * @since: 2016-01-15
+ */
+namespace Domino\CacheStore\Storage;
+
+/**
+ * Class NoCache
+ *
+ * @package Domino\CacheStore\Storage
+ */
+class NoCache implements StorageInterface
+{
+    /**
+     * Constructor
+     *
+     * @param array $option cache store storage option
+     */
+    public function __construct($option = array()) {}
+
+    /**
+     * Set item
+     *
+     * @param string $namespace
+     * @param string $key
+     * @param mixed $value
+     * @param integer $ttl expiration time (sec)
+     */
+    public function set($namespace, $key, $value, $ttl = null) {}
+
+    /**
+     * Get item
+     *
+     * @param  string $namespace
+     * @param  string $key
+     * @return mixed             stored item
+     */
+    public function get($namespace, $key)
+    {
+        return null;
+    }
+
+    /**
+     * Clear item
+     *
+     * @param  string $namespace
+     * @param  string $key
+     * @return boolean            success or failure
+     */
+    public function clear($namespace, $key)
+    {
+        return true;
+    }
+
+    /**
+     * Clear by namespace
+     *
+     * @param  string $namespace
+     * @return boolean            success or failure
+     */
+    public function clearByNamespace($namespace)
+    {
+        return true;
+    }
+
+    /**
+     * Clear all
+     *
+     * @return boolean success or failure
+     */
+    public function clearAll()
+    {
+        return true;
+    }
+}

--- a/tests/Domino/CacheStore/Tests/FactoryTest.php
+++ b/tests/Domino/CacheStore/Tests/FactoryTest.php
@@ -22,6 +22,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         CacheStore\Factory::clearOptions();
+        CacheStore\Factory::enableCaching();
     }
 
     public function testOptions()
@@ -36,10 +37,10 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testOption()
     {
-        $set_apc_option = array("storage" => 'apc', 'default_ttl' => 10);
+        $set_apc_option = array('storage' => 'apc', 'default_ttl' => 10);
         CacheStore\Factory::setOption($set_apc_option);
 
-        $set_memcached_option = array("storage" => 'memcached', 'option1' => 20);
+        $set_memcached_option = array('storage' => 'memcached', 'option1' => 20);
         CacheStore\Factory::setOption($set_memcached_option);
 
         $get_apc_option = CacheStore\Factory::getOption('apc');
@@ -60,6 +61,10 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryMemcached()
     {
+        if (!extension_loaded('memcached')) {
+            $this->markTestSkipped('Memcached extension is not loaded');
+        }
+
         $memcached_option = array('storage' => 'memcached', 'default_ttl' => 10, 'prefix' => '_md', 'servers' => array());
         CacheStore\Factory::setOption($memcached_option);
 
@@ -69,6 +74,10 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryMemcache()
     {
+        if (!extension_loaded('memcache')) {
+            $this->markTestSkipped('Memcache extension is not loaded');
+        }
+
         $memcached_option = array('storage' => 'memcache', 'default_ttl' => 10, 'prefix' => '_md', 'servers' => array());
         CacheStore\Factory::setOption($memcached_option);
 
@@ -93,7 +102,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         // register custom storage
         $customStorage = $this->getMock('Domino\CacheStore\Storage\StorageInterface');
         CacheStore\Factory::registerStorage('custom', get_class($customStorage));
-        $cacheStore = CacheStore\Factory::factory('custom', get_class($customStorage));
+        $cacheStore = CacheStore\Factory::factory('custom');
         $this->assertInstanceOf(get_class($customStorage), $cacheStore);
 
         // try to register custom storage with bad interface
@@ -123,5 +132,34 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $store2 = CacheStore\Factory::factory('apc');
 
         $this->assertNotSame($store1, $store2);
+    }
+
+    public function testDisableCache()
+    {
+        CacheStore\Factory::disableCaching();
+        $storage = CacheStore\Factory::factory('apc');
+
+        $this->assertInstanceOf('\Domino\CacheStore\Storage\NoCache', $storage);
+    }
+
+    public function testDisableAndEnableCache()
+    {
+        //begin of setup
+        $name           = 'custom';
+        /** @var CacheStore\Storage\StorageInterface $storageMock */
+        $storageMock    = $this->getMock('Domino\CacheStore\Storage\StorageInterface');
+        CacheStore\Factory::registerStorage($name, get_class($storageMock));
+        //end of setup
+
+        //begin of assertions
+        $customStorage  = CacheStore\Factory::factory($name);
+        CacheStore\Factory::disableCaching();
+        $noCacheStorage = CacheStore\Factory::factory($name);
+
+        $this->assertInstanceOf('\Domino\CacheStore\Storage\NoCache', $noCacheStorage);
+        CacheStore\Factory::enableCaching();
+
+        $this->assertSame($customStorage, CacheStore\Factory::factory($name));
+        //end of assertions
     }
 }

--- a/tests/Domino/CacheStore/Tests/Storage/NoCacheTest.php
+++ b/tests/Domino/CacheStore/Tests/Storage/NoCacheTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author: stev leibelt <artodeto@bazzline.net>
+ * @since: 2016-01-15
+ */
+namespace Domino\CacheStore\Tests\Storage;
+
+use Domino\CacheStore\Storage\NoCache;
+
+class NoCacheTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var NoCache */
+    private $storage;
+
+    public function setUp()
+    {
+        $this->storage = new NoCache(array());
+    }
+
+    public function testSet()
+    {
+        $this->storage->set('namespace', 'key', 'value');
+    }
+
+    public function testGet()
+    {
+        $result = $this->storage->get('namespace', 'key');
+        $this->assertNull($result);
+    }
+
+    public function testGetWhenKeyNotExist()
+    {
+        $this->assertNull($this->storage->get('namespace', 'key'));
+    }
+
+    public function testClear()
+    {
+        $this->storage->set('namespace', 'key', 'value');
+        $this->storage->clear('namespace', 'key');
+
+        $this->assertNull($this->storage->get('namespace', 'key'));
+    }
+
+    public function testClearByNamespace()
+    {
+        $this->storage->set('namespace1', 'key1', 'value1');
+        $this->storage->set('namespace1', 'key2', 'value2');
+        $this->storage->set('namespace2', 'key3', 'value3');
+
+        $this->storage->clearByNamespace('namespace1');
+        $this->assertNull($this->storage->get('namespace1', 'key1'));
+        $this->assertNull($this->storage->get('namespace1', 'key2'));
+        $this->assertNull($this->storage->get('namespace2', 'key3'));
+    }
+}


### PR DESCRIPTION
Hey there,

we are using the [propel cache behavior](https://github.com/SNakano/PropelDataCacheBehavior). In our business case, it is possible that the cache can be disabled via runtime configuration without a generation and deployment of the propel files (where $cacheEnable is true).

For that case, I have added two new static methods to the class 'Factory', 'disableCaching' and 'enableCaching'.
If you call 'disableCaching', the factory will return an instance of the class 'NoCache' until you call 'enableCaching'.
The idea behind this is to provide a class that implements the 'StorageInterface' but does not cache anything (also know as DummyCache or NullCache).

While adding the unit tests, I was so kind to add 'phpunit' to the development requirement in the fitting composer section.
While trying to execute the unit tests, I copied the behavior of the storage tests into the factory test. The factory test now also checks, if the fitting extension is installed and if not, marks the test as skipped.

Finally, I added an example in the 'README.md'.

I hope you like this, especially the naming.
If you merge it, would you be so kind to create a new release and also update your [propel cache behavior](https://github.com/SNakano/PropelDataCacheBehavior)?
As mentioned at the beginning, we want to use this feature and would like to switch back to the original library instead of shipping our patched version.

Kind regards,
Stev
